### PR TITLE
Reduce avg response time from 250ms to 100ms

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,13 +27,13 @@ resource "aws_instance" "web_app" {
   instance_type = var.instance_type # <<<<< Try changing this to a1.xlarge to compare the costs
 
   root_block_device {
-    volume_size = 50
+    volume_size = 150
   }
 
   ebs_block_device {
     device_name = "my_data"
     volume_type = "io1"             # <<<<< Try changing this to gp2 to compare costs
-    volume_size = 50
+    volume_size = 200
     iops        = var.iops
   }
 }
@@ -50,5 +50,5 @@ resource "aws_lambda_function" "hello_world" {
 data "infracost_aws_lambda_function" "hello_world" {
   resources = [aws_lambda_function.hello_world.id]
   monthly_requests { value = 100000000 }
-  average_request_duration { value = 250 } # <<<<< Try changing this to 100 (milliseconds) to compare costs
+  average_request_duration { value = 100 } # <<<<< Try changing this to 100 (milliseconds) to compare costs
 }


### PR DESCRIPTION
If we refactor this Lambda function to remove the synchronous logging code, it can save us 11%. What do you think guys?